### PR TITLE
Duplicate shipping method issue fixed

### DIFF
--- a/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Eparcel.php
+++ b/src/app/code/community/Fontis/Australia/Model/Shipping/Carrier/Eparcel.php
@@ -73,7 +73,7 @@ class Fontis_Australia_Model_Shipping_Carrier_Eparcel
                     $method->setCarrier('eparcel');
                     $method->setCarrierTitle($this->getConfigData('title'));
                     if ($this->_getChargeCode($rate)) {
-                        $_method = strtolower(str_replace(' ', '_', $this->_getChargeCode($rate)));
+                    	$_method = strtolower(str_replace(' ', '_', $this->_getChargeCode($rate))).'_'.$rate['pk'];
                     } else {
                         $_method = strtolower(str_replace(' ', '_', $rate['delivery_type']));
                     }


### PR DESCRIPTION
One of our client reported the issue when they go on checkout page and click estimate shipping it give shipping options i.e. 
- eParcel Standard + Postage Insurance $19.00
- eParcel Express $30.00 
but when they select on of the option and click update total it won't take and calculate that selected option

The issue is duplicate payment method code, so, the radio buttons have duplicate values beased on payment method and it always taken the first value.

To fix it, I have modified the code and bind Primary Key value with Payment Method Code, so, it will always remain unique.